### PR TITLE
Add Brake Cyclinder Pressure to DPU Info HUD.

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs
@@ -17,6 +17,7 @@
 
 using Microsoft.Xna.Framework;
 using Orts.Parsers.Msts;
+using Orts.Simulation.RollingStocks.SubSystems.Brakes;
 using Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions;
 using ORTS.Common;
 using ORTS.Scripting.Api;
@@ -398,6 +399,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             labels.AppendFormat("{0}{1}", Simulator.Catalog.GetString("Load"), tabs);
             labels.AppendFormat("{0}{1}", Simulator.Catalog.GetString("RPM"), tabs);
             labels.AppendFormat("{0}{1}", Simulator.Catalog.GetString("Flow"), tabs);
+            labels.AppendFormat("{0}{1}", Simulator.Catalog.GetString("Brake Cylinder"), tabs);
             labels.AppendFormat("{0}{1}", Simulator.Catalog.GetString("Temperature"), tabs);
             labels.AppendFormat("{0}{1}", Simulator.Catalog.GetString("Oil Pressure"), tabs);
             return labels.ToString();
@@ -468,6 +470,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             result.AppendFormat("\t{0:F1}%", eng.LoadPercent);
             result.AppendFormat("\t{0:F0} {1}", eng.RealRPM, FormatStrings.rpm);
             result.AppendFormat("\t{0}", FormatStrings.FormatAirFlow(Locomotive.FilteredBrakePipeFlowM3pS, Locomotive.IsMetric));
+            var brakeCylValue = Locomotive.BrakeSystem != null ? Math.Round(Locomotive.BrakeSystem.GetCylPressurePSI()).ToString() + " psi" : "?";
+            result.AppendFormat("\t{0}", brakeCylValue);
             result.AppendFormat("\t{0}", FormatStrings.FormatTemperature(eng.DieselTemperatureDeg, Locomotive.IsMetric, false));
             result.AppendFormat("\t{0}", FormatStrings.FormatPressure(eng.DieselOilPressurePSI, PressureUnit.PSI, Locomotive.MainPressureUnit, true));
 


### PR DESCRIPTION
Abandoned branch, as it is not worth adding the Brake Cylinder pressure to the HUD. It already is in the DPU pop-up.

The changes are in more generalized files. But I verified that the affected functions are only used by the HUD.

```
TextPageDistributedPowerInfo  HudWindow.cs  --  the DPU Hud
	GetDebugTableBase  MSTSDieselLocomotives.cs    --  
		SetDebugLabels  MSTSDieselLocomotives.cs  --  sets part 1 labels; 1 caller
			SetDebugLabels  DieselEngin.cs  --  sets part 2 labels; 1 caller
	for each loco
		GetDPDebugStatus  MSTSDieselLocomotives.cs    -- set part 1 values; 1 caller
			GetDPStatus  DieselEngin.cs  --  sets part 2 values; 1 caller
```

Browser Before and After:

![image](https://github.com/rwf-rr/rwf-openrails/assets/159661206/96cdaa8d-869d-4d81-a69b-236b3ebd5ffe)

![image](https://github.com/rwf-rr/rwf-openrails/assets/159661206/17dc9891-a171-4374-8317-ab563a8c05f0)

Display (overlay) Before and After:

![image](https://github.com/rwf-rr/rwf-openrails/assets/159661206/bf354725-f7c7-4603-8f5d-2676763dae6d)

![image](https://github.com/rwf-rr/rwf-openrails/assets/159661206/8ac5a5e6-9c5c-43d1-8530-4d65a3dca8d3)

The DPU PopUp is not affected:

![image](https://github.com/rwf-rr/rwf-openrails/assets/159661206/211118ec-4ccd-4800-b7f2-42d586e91eca)


