### PR TITLE
Settings Exporter - private PR

### DIFF
--- a/Source/Contrib/SettingsExporter/Program.cs
+++ b/Source/Contrib/SettingsExporter/Program.cs
@@ -1,0 +1,244 @@
+﻿// COPYRIGHT 2025 by the Open Rails project.
+// 
+// This file is part of Open Rails.
+// 
+// Open Rails is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Open Rails is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
+
+// Export the Settings in the Registry into an INI file, or vice versa.
+// In order to support multiple installations with different settings,
+// OpenRails supports using an INI file for the settings (instead of
+// the registry entries that are shared by all installations).
+// OpenRails creates a default INI file when the file exists, but has no
+// settings. This tool exports the current settings from the registry to
+// the INI file. It also allows the reverse.
+
+// Important: UpdateSettings, part of UpdateManager has its own file,
+//            Updater.ini.
+//
+// FUTURE: New settings classes that are not part of UserSettings need to
+//         be added to the exporter. See FUTURE tag below.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Win32;
+using ORTS.Common;
+using ORTS.Settings;
+
+namespace ORTS.SettingsExporter
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            string fromArg = null; string toArg = null;
+
+            #region Parse Args
+            // parse arguments
+            foreach (string arg in args)
+            {
+                if (arg.Equals("/h") || arg.Equals("/help")) { ShowHelp(); Environment.Exit(1); }
+                else if (arg.StartsWith("/")) { Console.WriteLine("ERROR: Invalid option {0}.", arg); ShowHelp(); Environment.Exit(1); }
+                else if (fromArg == null) { fromArg = arg; }
+                else if (toArg == null) { toArg = arg; }
+                else { Console.WriteLine("ERROR: extraneous argument {0}.", arg); ShowHelp(); Environment.Exit(1); }
+            }
+            if (String.IsNullOrEmpty(fromArg) || String.IsNullOrEmpty(toArg))
+            { Console.WriteLine("ERROR: Missing from or to argument."); ShowHelp(); Environment.Exit(1); }
+            else if (fromArg.Equals(toArg))
+            { Console.WriteLine("ERROR: From {0} and to {1} must not be the same.", fromArg, toArg); ShowHelp(); Environment.Exit(1); }
+            #endregion
+
+            string loadFilePath = null; string loadRegistryKey = null;
+
+            #region Determine From
+            // determine where to load from
+            if (fromArg.Equals("INI")) { loadFilePath = SettingsBase.DefaultSettingsFileName; }
+            else if (fromArg.Equals("REG")) { loadRegistryKey = SettingsBase.DefaultRegistryKey; }
+            else if (fromArg.EndsWith(".ini")) { loadFilePath = fromArg; }
+            else { loadRegistryKey = fromArg; }
+
+            // check that source exists
+            if (!String.IsNullOrEmpty(loadFilePath))
+            {
+                var iniFilePath = Path.Combine(ApplicationInfo.ProcessDirectory, loadFilePath);
+                if (!File.Exists(iniFilePath))
+                {
+                    Console.WriteLine("ERROR: INI file {0} to export from does not exist.", iniFilePath);
+                    Environment.Exit(1);
+                }
+            }
+            else if (!String.IsNullOrEmpty(loadRegistryKey))
+            {
+                using (var regKey = Registry.CurrentUser.OpenSubKey(loadRegistryKey))
+                {
+                    if (regKey == null)
+                    {
+                        Console.WriteLine("ERROR: Reg key {0} to export from does not exist.", loadRegistryKey);
+                        Environment.Exit(1);
+                    }
+                }
+            }
+            else
+            {
+                Console.WriteLine("ERROR: No source to export from found");
+                Environment.Exit(1);
+            }
+            #endregion
+
+            // instantiate the static part of SettingsBase
+            UserSettings userSettings;
+
+            // then override
+            SettingsBase.OverrideSettingsLocations(loadFilePath, loadRegistryKey);
+
+            Console.WriteLine("Info: Loading from {0}.", SettingsBase.RegistryKey + SettingsBase.SettingsFilePath);
+
+            // load the user settings and its sub-settings from the default location
+            IEnumerable<string> options = Enumerable.Empty<string>();
+            userSettings = new UserSettings(options);
+            var updateState = new UpdateState();
+            // FUTURE: add here when a new settings class is added (that is not handled by UserSettings)
+
+            Console.WriteLine("Info: Successfully loaded settings from {0}.", userSettings.GetSettingsStoreName());
+
+            string saveFilePath = null; string saveRegistryKey = null;
+
+            #region Determine To
+            // determine where to save to
+            if (toArg.Equals("INI")) { saveFilePath = SettingsBase.DefaultSettingsFileName; }
+            else if (toArg.Equals("REG")) { saveRegistryKey = SettingsBase.DefaultRegistryKey; }
+            else if (toArg.Contains(".ini"))
+            {
+                // save to a custom ini file, do some basic verification
+                saveFilePath = toArg;
+                var dir = Path.GetDirectoryName(Path.Combine(ApplicationInfo.ProcessDirectory, saveFilePath));
+                if (!Directory.Exists(dir)) { Console.WriteLine("ERROR: Directory {0} to save to does not exist.", dir); Environment.Exit(1); }
+            }
+            else
+            {
+                // load from a custom registry key
+                saveRegistryKey = toArg;
+            }
+            #endregion
+
+            #region Backup
+            if (!String.IsNullOrEmpty(saveFilePath))
+            {
+                // backup the file if it already exists
+                string settingsFilePath = Path.Combine(ApplicationInfo.ProcessDirectory, saveFilePath);
+                string backupFilePath = Path.Combine(ApplicationInfo.ProcessDirectory, saveFilePath + ".bak");
+                if (File.Exists(settingsFilePath))
+                {
+                    File.Delete(backupFilePath);
+                    File.Move(settingsFilePath, backupFilePath);
+                    Console.WriteLine("Info: Backed up existing INI file as {0}.", backupFilePath);
+                }
+
+                // create an empty file (required by SettingsStore)
+                using (File.Create(settingsFilePath)) { };
+
+            }
+            else if (!String.IsNullOrEmpty(saveRegistryKey))
+            {
+                // backup the registry key if it already exists
+                using (var regKey = Registry.CurrentUser.OpenSubKey(saveRegistryKey))
+                {
+                    if (regKey != null)
+                    {
+                        using (var backupRegKey = Registry.CurrentUser.CreateSubKey(saveRegistryKey + "-Backup"))
+                        { 
+                            CopyRegistryKey(regKey, backupRegKey);
+                            Console.WriteLine("Info: Backed up existing Registry key as {0}.", backupRegKey.Name);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                Console.WriteLine("ERROR: No destination to export to.");
+                Environment.Exit(1);
+            }
+            #endregion
+
+            // change the settings store
+            userSettings.ChangeSettingsStore(saveFilePath, saveRegistryKey, null);  // section is defined in SettingsStoreLocalIni
+            updateState.ChangeSettingsStore(saveFilePath, saveRegistryKey, UpdateState.SectionName);
+            // FUTURE: add here when a new settings class is added (that is not handled by UserSettings)
+
+            Console.WriteLine("Info: Saving to {0}.", userSettings.GetSettingsStoreName());
+
+            // save the settings
+            userSettings.Save();
+            updateState.Save();
+            // FUTURE: add here when a new settings class is added (that is not handled by UserSettings)
+
+            Console.WriteLine("Info: Successfully saved to {0}.", userSettings.GetSettingsStoreName());
+            return 0;
+        }
+
+        static void ShowHelp()
+        {
+            string cmd = Path.GetFileNameWithoutExtension(ApplicationInfo.ProcessFile);
+            Console.WriteLine();
+            Console.WriteLine("Usage: {0} <from> <to>", cmd);
+            Console.WriteLine("  <from>     Specify the source to load settings from. It may be:");
+            Console.WriteLine("               INI  : use the default INI file {0}.", SettingsBase.DefaultSettingsFileName);
+            Console.WriteLine("               REG  : use the default registry key {0}.", SettingsBase.DefaultRegistryKey);
+            Console.WriteLine("               path : a specific INI file, relative to the OpenRails main folder. Must end with \".ini\".");
+            Console.WriteLine("               key  : a specific registry key, relative to the HKEY_CURRENT_USER key.");
+            Console.WriteLine("  <to>       Specify the destination to save the settings to. Similar to <from>.");
+            Console.WriteLine("  /h, /help  Show this help.");
+            Console.WriteLine();
+            Console.WriteLine("This utility reads the Settings (Options) from one location, and exports them to another location.");
+            Console.WriteLine("It creates a backup of any settings that will be overwritten. Example:");
+            Console.WriteLine("  <installfolder>\\OpenRails.ini.bak");
+            Console.WriteLine("  HKEY_CURRENT_USER\\SOFTWARE\\OpenRails\\ORTS-Backup");
+            Console.WriteLine("This utility is intended to:");
+            Console.WriteLine("- Create an INI file that has the same settings as what is in the registry.");
+            Console.WriteLine("  Example: {0} REG INI", cmd);
+            Console.WriteLine("- Copy the settings from an INI file back into the registry, so that other installations");
+            Console.WriteLine("  use the same settings.");
+            Console.WriteLine("  Example: {0} INI REG", cmd);
+            Console.WriteLine("- Backup the settings, before making temporary changes (and restore afterwards).");
+            Console.WriteLine("  Example: {0} REG SOFTWARE\\OpenRails-Saved\\ORTS", cmd);
+            Console.WriteLine();
+        }
+
+        /// <summary>
+        /// Recursively copy the values of a registry key to another registry key.
+        /// </summary>
+        /// <param name="fromKey">the key to copy from; must exist</param>
+        /// <param name="toKey">the key to copy to; should not exist</param>
+        static void CopyRegistryKey(RegistryKey fromKey, RegistryKey toKey)
+        {
+            // copy the values
+            foreach (var name in fromKey.GetValueNames())
+            {
+                toKey.SetValue(name, fromKey.GetValue(name), fromKey.GetValueKind(name));
+            }
+
+            // copy the subkeys
+            foreach (var name in fromKey.GetSubKeyNames())
+            {
+                using (var fromSubKey = fromKey.OpenSubKey(name))
+                {
+                    var toSubKey = toKey.CreateSubKey(name);
+                    CopyRegistryKey(fromSubKey, toSubKey);
+                }
+            }
+        }
+    }
+}

--- a/Source/Contrib/SettingsExporter/SettingsExporter.csproj
+++ b/Source/Contrib/SettingsExporter/SettingsExporter.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFramework>
+    <TargetFramework Condition="'$(TargetFramework)' == ''">net472</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Orts.SettingsExporter</RootNamespace>
+    <AssemblyName>Contrib.SettingsExporter</AssemblyName>
+    <ApplicationIcon>..\..\ORTS.ico</ApplicationIcon>
+    <IsPublishable>False</IsPublishable>
+    <AssemblyTitle>Open Rails Settings Exporter (Contributed)</AssemblyTitle>
+    <Description>Export ORTS Settings from the Registry to the INI file, or vice versa.</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2025</Copyright>
+    <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\ORTS.Common/ORTS.Common.csproj" />
+    <ProjectReference Include="..\..\ORTS.Settings/ORTS.Settings.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/Source/ORTS.Common/SettingsBase.cs
+++ b/Source/ORTS.Common/SettingsBase.cs
@@ -157,7 +157,9 @@ namespace ORTS.Common
 
         /// <summary>
         /// Change the settings store. Creates a new SettingsStore based on the provided parameters.
-        /// See also SettingsStore.GetSettingStore().
+        /// Only one of filePath and registry key should be specified. If both are provided, filePath
+        /// prevails. Does not change the static locations (as that would affect other objects).
+        /// See also SettingsStore.GetSettingStore() and OverrideSettingsLocations().
         /// </summary>
         /// <param name="filePath">The path to the INI file, or NULL if using the registry.</param>
         /// <param name="registryKey">The registry key (name), or NULL if using an INI file. </param>
@@ -169,7 +171,8 @@ namespace ORTS.Common
                 SettingStore.Discard();
                 SettingStore = null;
             }
-            SettingStore = SettingsStore.GetSettingStore(filePath, registryKey, section);
+            var fullPath = String.IsNullOrEmpty(filePath) ? null : Path.Combine(ApplicationInfo.ProcessDirectory, filePath);
+            SettingStore = SettingsStore.GetSettingStore(fullPath, registryKey, section);
         }
 
         /// <summary>

--- a/Source/ORTS.Common/SettingsStore.cs
+++ b/Source/ORTS.Common/SettingsStore.cs
@@ -148,6 +148,12 @@ namespace ORTS.Common
         }
 
         /// <summary>
+        /// Get the name of the settings store.
+        /// </summary>
+        public abstract String GetStoreName();
+
+
+        /// <summary>
         /// Factory method to create a setting store (sub-class of SettingsStore)
         /// </summary>
         /// <param name="filePath">File patht o a .init file, if you want to use a .ini file</param>
@@ -329,6 +335,16 @@ namespace ORTS.Common
                 Key.Close();
                 // cannot set to null, as Key (and string version) are readonly
             }
+        }
+
+        /// <summary>
+        /// Get the name of the settings store, in this case the registry key.
+        /// </summary>
+        public override String GetStoreName()
+        {
+            string name = "None (registry)";
+            if (Key != null) { name = Key.Name; }
+            return name;
         }
 	}
 
@@ -552,7 +568,17 @@ namespace ORTS.Common
 		{
 			NativeMethods.WritePrivateProfileString(Section, name, null, FilePath);
 		}
-	}
+
+        /// <summary>
+        /// Get the name of the settings store, in this case the INI file path.
+        /// </summary>
+        public override String GetStoreName()
+        {
+            string name = "None (file)";
+            if (!String.IsNullOrEmpty(FilePath)) { name = FilePath; }
+            return name;
+        }
+    }
 
     // TODO: This class and its methods should be internal visibility.
     /// <summary>

--- a/Source/ORTS.Settings/ContentSettings.cs
+++ b/Source/ORTS.Settings/ContentSettings.cs
@@ -24,12 +24,14 @@ namespace ORTS.Settings
 {
     public class ContentSettings : SettingsBase
     {
+        public static readonly string SectionName = "ContentRoutes";
+
         #region User Settings
         public ContentRouteSettings ContentRouteSettings;
         #endregion
 
         public ContentSettings(IEnumerable<string> options)
-        : base(SettingsStore.GetSettingStore(SettingsBase.SettingsFilePath, SettingsBase.RegistryKey, "ContentRoutes"))
+        : base(SettingsStore.GetSettingStore(SettingsBase.SettingsFilePath, SettingsBase.RegistryKey, SectionName))
         {
             ContentRouteSettings = new ContentRouteSettings();
             Load(options);

--- a/Source/ORTS.Settings/FolderSettings.cs
+++ b/Source/ORTS.Settings/FolderSettings.cs
@@ -26,10 +26,12 @@ namespace ORTS.Settings
 {
     public class FolderSettings : SettingsBase
     {
+        public static readonly string SectionName = "Folders";
+
         public readonly Dictionary<string, string> Folders;
 
         public FolderSettings(IEnumerable<string> options)
-            : base(SettingsStore.GetSettingStore(SettingsBase.SettingsFilePath, SettingsBase.RegistryKey, "Folders"))
+            : base(SettingsStore.GetSettingStore(SettingsBase.SettingsFilePath, SettingsBase.RegistryKey, SectionName))
         {
             Folders = new Dictionary<string, string>();
             Load(options);

--- a/Source/ORTS.Settings/InputSettings.cs
+++ b/Source/ORTS.Settings/InputSettings.cs
@@ -62,6 +62,8 @@ namespace ORTS.Settings
     /// </remarks>
     public class InputSettings : SettingsBase
     {
+        public static readonly string SectionName = "Keys";
+
         static GettextResourceManager commonCatalog = new GettextResourceManager("ORTS.Common");
         static GettextResourceManager settingsCatalog = new GettextResourceManager("ORTS.Settings");
 
@@ -79,7 +81,7 @@ namespace ORTS.Settings
         /// </summary>
         /// <param name="options">The list of one-time options to override persisted settings, if any.</param>
         public InputSettings(IEnumerable<string> options)
-        : base(SettingsStore.GetSettingStore(SettingsBase.SettingsFilePath, SettingsBase.RegistryKey, "Keys"))
+        : base(SettingsStore.GetSettingStore(SettingsBase.SettingsFilePath, SettingsBase.RegistryKey, SectionName))
         {
             InitializeCommands(Commands);
             Load(options);

--- a/Source/ORTS.Settings/RailDriverSettings.cs
+++ b/Source/ORTS.Settings/RailDriverSettings.cs
@@ -44,6 +44,8 @@ namespace ORTS.Settings
 
     public class RailDriverSettings : SettingsBase
     {
+        public static readonly string SectionName = "RailDriver";
+
         static readonly GettextResourceManager catalog = new GettextResourceManager("ORTS.Settings");
         private static readonly byte[] DefaultCalibrationSettings;
         private static readonly Dictionary<UserCommand, byte> DefaultUserCommands;
@@ -119,7 +121,7 @@ namespace ORTS.Settings
         /// </summary>
         /// <param name="options">The list of one-time options to override persisted settings, if any.</param>
         public RailDriverSettings(IEnumerable<string> options)
-        : base(SettingsStore.GetSettingStore(SettingsBase.SettingsFilePath, SettingsBase.RegistryKey, "RailDriver"))
+        : base(SettingsStore.GetSettingStore(SettingsBase.SettingsFilePath, SettingsBase.RegistryKey, SectionName))
         {
             CalibrationSettings = new byte[DefaultCalibrationSettings.Length];
 

--- a/Source/ORTS.Settings/UpdateState.cs
+++ b/Source/ORTS.Settings/UpdateState.cs
@@ -26,6 +26,8 @@ namespace ORTS.Settings
 {
     public class UpdateState : SettingsBase
     {
+        public static readonly string SectionName = "UpdateState";
+
         #region User Settings
 
         // Please put all update settings in here as auto-properties. Public properties
@@ -41,7 +43,7 @@ namespace ORTS.Settings
         #endregion
 
         public UpdateState()
-            : base(SettingsStore.GetSettingStore(SettingsBase.SettingsFilePath, SettingsBase.RegistryKey, "UpdateState"))
+            : base(SettingsStore.GetSettingStore(SettingsBase.SettingsFilePath, SettingsBase.RegistryKey, SectionName))
         {
             Load(new string[0]);
         }

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -594,11 +594,11 @@ namespace ORTS.Settings
         /// <param name="section">Optional, the name of the section / subkey.</param>
         public override void ChangeSettingsStore(string filePath, string registryKey, string section)
         {
-            base.ChangeSettingsStore(filePath, registryKey, section);
-            Folders.ChangeSettingsStore(filePath, registryKey, section);
-            Input.ChangeSettingsStore(filePath, registryKey, section);
-            RailDriver.ChangeSettingsStore(filePath, registryKey, section);
-            Content.ChangeSettingsStore(filePath, registryKey, section);
+            base.ChangeSettingsStore(filePath, registryKey, section);  // section is defined in SettingsStoreLocalIni
+            Folders.ChangeSettingsStore(filePath, registryKey, FolderSettings.SectionName);
+            Input.ChangeSettingsStore(filePath, registryKey, InputSettings.SectionName);
+            RailDriver.ChangeSettingsStore(filePath, registryKey, RailDriverSettings.SectionName);
+            Content.ChangeSettingsStore(filePath, registryKey, ContentSettings.SectionName);
         }
 
         public void Log()

--- a/Source/ORTS.sln
+++ b/Source/ORTS.sln
@@ -53,6 +53,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ContentChecker", "ContentCh
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimulatorTester", "Contrib\SimulatorTester\SimulatorTester.csproj", "{792B01A1-5C43-4FFA-A4C0-BBDC95A4A178}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SettingsExporter", "Contrib\SettingsExporter\SettingsExporter.csproj", "{FAD444CE-3EA7-47AC-A771-792E34BCE7DC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -159,6 +161,10 @@ Global
 		{792B01A1-5C43-4FFA-A4C0-BBDC95A4A178}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{792B01A1-5C43-4FFA-A4C0-BBDC95A4A178}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{792B01A1-5C43-4FFA-A4C0-BBDC95A4A178}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FAD444CE-3EA7-47AC-A771-792E34BCE7DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAD444CE-3EA7-47AC-A771-792E34BCE7DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAD444CE-3EA7-47AC-A771-792E34BCE7DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAD444CE-3EA7-47AC-A771-792E34BCE7DC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This is the SettingsExporter, to be added on top of the refactoring https://github.com/openrails/openrails/pull/1030.
Only the files Program.cs, SettingsExporter.csproj and Source/ORTS.sln are relevant.

I don't know why the PR is showing the complete changes, I am comparing to the refactor-user-settings-location branch.